### PR TITLE
text.js: messages are being cleared before validation routine

### DIFF
--- a/form/input/text/text.js
+++ b/form/input/text/text.js
@@ -141,6 +141,7 @@ Vue.component("n-form-text", {
 			this.$emit('keyup', $event);
 		},
 		validate: function(soft) {
+			this.messages.splice(0, this.messages.length);
 			var messages = nabu.utils.schema.json.validate(this.definition, this.value, this.mandatory);
 			for (var i = 0; i < messages.length; i++) {
 				messages[i].component = this;


### PR DESCRIPTION
Voorheen werd this.messages niet leeggemaakt bij het oproepen van de validate methode.
Dit leidt ertoe dat foutboodschappen bij elke klik op de knop opnieuw worden verdubbeld.