### PR TITLE
Form/combo.js : validate local messages

### DIFF
--- a/form/input/combo/combo.js
+++ b/form/input/combo/combo.js
@@ -82,28 +82,28 @@ Vue.component("n-form-combo", {
 		}
 	},
 	template: "#n-form-combo",
-	data: function () {
+	data: function() {
 		return {
 			valid: null,
 			messages: []
 		}
 	},
 	computed: {
-		definition: function () {
+		definition: function() {
 			return nabu.utils.vue.form.definition(this);
 		},
-		mandatory: function () {
+		mandatory: function() {
 			return nabu.utils.vue.form.mandatory(this);
 		}
 	},
 	methods: {
-		validate: function (soft) {
+		validate: function(soft) {
 			this.messages.splice(0, this.messages.length);
 			var messages = nabu.utils.schema.json.validate(this.definition, this.value, this.mandatory);
 			for (var i = 0; i < messages.length; i++) {
 				messages[i].component = this;
 			}
-			var hardMessages = messages.filter(function (x) { return !x.soft });
+			var hardMessages = messages.filter(function(x) { return !x.soft });
 			// if we are doing a soft validation and all messages were soft, set valid to unknown
 			if (soft && hardMessages.length == 0 && messages.length > 0 && this.valid == null) {
 				this.valid = null;
@@ -114,10 +114,10 @@ Vue.component("n-form-combo", {
 			}
 			return messages;
 		},
-		updateValue: function (value, label) {
+		updateValue: function(value, label) {
 			this.$emit("input", value, label);
 		},
-		clear: function () {
+		clear: function() {
 			this.$refs.combo.clear();
 		}
 	}

--- a/form/input/combo/combo.js
+++ b/form/input/combo/combo.js
@@ -74,41 +74,50 @@ Vue.component("n-form-combo", {
 		},
 		autocomplete: {
 			type: String,
-      required: false
-    },
+			required: false
+		},
 		autoselectSingle: {
 			type: Boolean,
 			required: false
 		}
 	},
 	template: "#n-form-combo",
-	data: function() {
+	data: function () {
 		return {
 			valid: null,
 			messages: []
 		}
 	},
 	computed: {
-		definition: function() {
+		definition: function () {
 			return nabu.utils.vue.form.definition(this);
 		},
-		mandatory: function() {
+		mandatory: function () {
 			return nabu.utils.vue.form.mandatory(this);
 		}
 	},
 	methods: {
-		validate: function() {
+		validate: function (soft) {
+			this.messages.splice(0, this.messages.length);
 			var messages = nabu.utils.schema.json.validate(this.definition, this.value, this.mandatory);
 			for (var i = 0; i < messages.length; i++) {
 				messages[i].component = this;
 			}
-			this.valid = messages.length == 0;
+			var hardMessages = messages.filter(function (x) { return !x.soft });
+			// if we are doing a soft validation and all messages were soft, set valid to unknown
+			if (soft && hardMessages.length == 0 && messages.length > 0 && this.valid == null) {
+				this.valid = null;
+			}
+			else {
+				this.valid = messages.length == 0;
+				nabu.utils.arrays.merge(this.messages, nabu.utils.vue.form.localMessages(this, messages));
+			}
 			return messages;
 		},
-		updateValue: function(value, label) {
+		updateValue: function (value, label) {
 			this.$emit("input", value, label);
 		},
-		clear: function() {
+		clear: function () {
 			this.$refs.combo.clear();
 		}
 	}


### PR DESCRIPTION
De form/input/combo.js maakte nog gebruik van een erg eenvoudige manier van valideren.
Bij deze is ze omgezet naar de nieuwe manier met 'localMessages'.
Reeds gevalideerd sinds 2 weken bij neo project.