### PR TITLE
bugfix for safari

### DIFF
--- a/form/input/date/date.sass
+++ b/form/input/date/date.sass
@@ -11,12 +11,13 @@ $n-form-line-height: 3rem !default;
 		display: inline-block;
 	}
 	.n-input-date {
-		z-index: 1000;
+		border: $border;
+		border-style: none solid none solid;
 		position: absolute;
 		top: 100%;
 		max-width: 25rem;
-		border: $border;
-		border-style: none solid none solid;
+		width: 100%;
+		z-index: 1000;
 		> * {
 			width: 100%;
 		}

--- a/input/date/date.sass
+++ b/input/date/date.sass
@@ -34,16 +34,21 @@ $n-form-line-height: 3rem !default;
 		color: $n-form-date-hero-contrast;
 		
 		.month {
+			display: inline-block;
 			font-weight: 700;
 			font-size: 1.2rem;
+			max-height: 3rem;
+			overflow: hidden;
+			width: calc(100% - 14rem);
 		}
 		a {
-			font-size: 1.625rem;
-			height: $n-form-line-height;
-			width: $n-form-line-height;
-			position: absolute;
 			background-color: inherit;
 			color: inherit;
+			display: inline-block;
+			font-size: 1.625rem;
+			height: $n-form-line-height;
+			vertical-align: top;
+			width: $n-form-line-height;
 			
 			&.n-input-date-previous-year {
 				left: 0;


### PR DESCRIPTION
Changed absolute positioning in table-caption's <a> elements. Now using display:inline-block; to mitigate strange behavior in Safari, where the table-caption would jump down several 10s of pixels on mouseover.
Also, added width:100%; in form/../date.sass to ensure full-width date popup on mobile phones.