### PR TITLE
add vertAlign for the date component's icon, so it's properly aligned

### DIFF
--- a/form/input/date/date.sass
+++ b/form/input/date/date.sass
@@ -31,6 +31,7 @@ $n-form-line-height: 3rem !default;
 		height: $n-form-line-height;
 		text-align: center;
 		display: inline-block;
+		vertical-align: top;
 		
 		&:before {
 			font-size: 1.35rem;


### PR DESCRIPTION
Het datum icoontje stond af en toe 1px ofzo te laag.
Door de vertical-align expliciet toe te voegen, komt dit niet langer voor